### PR TITLE
Use field aliases in popups if available

### DIFF
--- a/qgis2leaf_exec.py
+++ b/qgis2leaf_exec.py
@@ -587,7 +587,7 @@ def qgis2leaf_exec(outputProjectFileName, basemapName, width, height, extent, fu
 								if str(field) == "icon_exp":
 									row += ""
 								else: 
-									row += """<tr><td>""" + str(field) + """</td><td>' + feature.properties.""" + str(field) + """ + '</td></tr>"""
+									row += """<tr><td>""" + i.attributeDisplayName(fields.indexFromName(str(field))) + """</td><td>' + feature.properties.""" + str(field) + """ + '</td></tr>"""
 							tableend = """</table>'"""
 							table = tablestart + row +tableend
 						#print table


### PR DESCRIPTION
If a field has an alias, use that as the attribute heading. If not, fall
back to the field name. Solution for #36
