### PR TITLE
Replicate source field visibility

### DIFF
--- a/qgis2leaf_exec.py
+++ b/qgis2leaf_exec.py
@@ -587,7 +587,8 @@ def qgis2leaf_exec(outputProjectFileName, basemapName, width, height, extent, fu
 								if str(field) == "icon_exp":
 									row += ""
 								else: 
-									row += """<tr><td>""" + i.attributeDisplayName(fields.indexFromName(str(field))) + """</td><td>' + feature.properties.""" + str(field) + """ + '</td></tr>"""
+									if i.editType(fields.indexFromName(field)) != QgsVectorLayer.Hidden:
+										row += """<tr><td>""" + i.attributeDisplayName(fields.indexFromName(str(field))) + """</td><td>' + feature.properties.""" + str(field) + """ + '</td></tr>"""
 							tableend = """</table>'"""
 							table = tablestart + row +tableend
 						#print table


### PR DESCRIPTION
Partial patch for #67. If any of a layer's attributes are set to
'Hidden' in QGIS, they will not appear in the Leaflet feature pop-up.
