### PR TITLE
Replace os.sep with "/" for js script path

### DIFF
--- a/qgis2leaf_exec.py
+++ b/qgis2leaf_exec.py
@@ -432,7 +432,7 @@ def qgis2leaf_exec(outputProjectFileName, basemapName, width, height, extent, fu
 						#now add the js files as data input for our map
 						with open(os.path.join(os.getcwd(),outputProjectFileName) + os.sep + 'index.html', 'a') as f3:
 							new_src = """
-				<script src='""" + 'data' + os.sep + """exp_""" + re.sub('[\W_]+', '', i.name()) + """.js' ></script>
+				<script src='""" + 'data' + '/' + """exp_""" + re.sub('[\W_]+', '', i.name()) + """.js' ></script>
 				"""
 							# store everything in the file
 							f3.write(new_src)


### PR DESCRIPTION
A user reported that leafelt maps generated by this plugin doesn't work on firefox. The cause of this was that if the index.html was generated on a windows machine, it has a separator '\' instead of '/'. Firefox fails to load this JS file since it can't interpret the path. While using os.sep is correct for system paths, for javascript paths, using forward slash would be better.
